### PR TITLE
Fixes bug with initially-selected button inside ViewGroup.

### DIFF
--- a/radiogroupplus/src/main/java/worker8/com/github/radiogroupplus/RadioGroupPlus.java
+++ b/radiogroupplus/src/main/java/worker8/com/github/radiogroupplus/RadioGroupPlus.java
@@ -351,8 +351,12 @@ public class RadioGroupPlus extends LinearLayout {
                     id = View.generateViewId();
                     view.setId(id);
                 }
-                ((RadioButton) view).setOnCheckedChangeListener(
-                        mChildOnCheckedChangeListener);
+
+                RadioButton radio = (RadioButton)view;
+                if (radio.isChecked()) {
+                    setCheckedId(id);
+                }
+                radio.setOnCheckedChangeListener(mChildOnCheckedChangeListener);
             }
             if (!(view instanceof ViewGroup)) {
                 return;


### PR DESCRIPTION
In the case where a `RadioButton` is defined with `android:checked="true"`, and that radio is inside another `ViewGroup` inside the `RadioGroupPlus`, the initially-checked state is never properly handled. When we try to check anything else, it doesn't realize that there was a checked view, so it doesn't get unchecked. Further, since the initial view is internally already in a checked state, tapping on it will never broadcast that it got checked, so no state changes happen.

This PR simply adds a check when traversing the tree to catch that case.